### PR TITLE
Lynx: pass --enable-externs to config

### DIFF
--- a/Formula/lynx.rb
+++ b/Formula/lynx.rb
@@ -43,6 +43,7 @@ class Lynx < Formula
                           "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}",
                           "--enable-ipv6",
                           "--with-screen=ncurses",
+                          "--enable-externs",
                           "--disable-config-info"
     system "make", "install"
   end


### PR DESCRIPTION
Lynx is a text based web browser for terminal. When one comes across a link to a video there is no way it can display that, it provides a feature to open the links in external program (like system's browser). But by default the configuration does not enable that, one needs to pass configuration flag ``--enable-externs``. Its missing in home-brew's version of lynx, please add it.

Links: 
1) https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/lynx.rb
2) https://formulae.brew.sh/formula/lynx

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
